### PR TITLE
[Hyeongjun] Add EmailController, Fix EmailService, AcoEmailSender

### DIFF
--- a/src/main/java/dev/aco/back/Controller/EmailController.java
+++ b/src/main/java/dev/aco/back/Controller/EmailController.java
@@ -1,0 +1,34 @@
+package dev.aco.back.Controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.aco.back.DTO.User.emailAuthDTO;
+import dev.aco.back.service.MailService.MailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = "/api/member")
+@Log4j2
+public class EmailController {
+  private final MailService mailService;
+
+  @RequestMapping(value = "emailauth", method = RequestMethod.POST, consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Boolean> emailRequest(@RequestBody emailAuthDTO dto) {
+    log.info(dto);
+    return new ResponseEntity<Boolean>(mailService.sendEmail(dto.getEmail()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/emailverify", method = RequestMethod.POST, consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<Boolean> verifyEmail(@RequestBody emailAuthDTO dto) {
+    log.info(dto);
+    return new ResponseEntity<Boolean>(mailService.verifyEmail(dto.getEmail()), HttpStatus.OK);
+  }
+}

--- a/src/main/java/dev/aco/back/Controller/EmailController.java
+++ b/src/main/java/dev/aco/back/Controller/EmailController.java
@@ -20,6 +20,7 @@ import lombok.extern.log4j.Log4j2;
 public class EmailController {
   private final MailService mailService;
 
+  // 요거 이름도 어디선 request에 어디선 send에 좀 통일이 필요한거같은데 뭐가 좋을까요?
   @RequestMapping(value = "emailauth", method = RequestMethod.POST, consumes = MediaType.ALL_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<Boolean> emailRequest(@RequestBody emailAuthDTO dto) {
     log.info(dto);

--- a/src/main/java/dev/aco/back/DTO/User/emailAuthDTO.java
+++ b/src/main/java/dev/aco/back/DTO/User/emailAuthDTO.java
@@ -1,0 +1,15 @@
+package dev.aco.back.DTO.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class emailAuthDTO {
+  String email;
+  Integer authNum;
+}

--- a/src/main/java/dev/aco/back/Utils/Redis/RedisManager.java
+++ b/src/main/java/dev/aco/back/Utils/Redis/RedisManager.java
@@ -76,10 +76,6 @@ public class RedisManager {
         valueOperations.set(key, value);
     }
 
-    // Redis에 저장하려고하다보니 유효기간 저장하는부분에서 문제가 생겼습니다.
-    // 검색해보면서 이런식으로 저장을 하는걸 보고 제가 이해하는 선에서 적어봤습니다.
-    // 이것이 문제가 될지 잘 모르겠습니다. 만약 이것을 사용한다면 기존 MailService에서 작성한
-    // 유효기간 관련된 코드는 사용할 필요가 없을것 같음.
     public void setDataExpire(String key, String value, long expiration) {
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         // expireDuaration 동안 (key, value)를 저장한다.

--- a/src/main/java/dev/aco/back/service/MailService/AcoMailSender.java
+++ b/src/main/java/dev/aco/back/service/MailService/AcoMailSender.java
@@ -2,10 +2,9 @@ package dev.aco.back.service.MailService;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
-// import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;
 
-// import dev.aco.back.Utils.Redis.RedisManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
@@ -13,8 +12,7 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 @Log4j2
 public class AcoMailSender {
-  // private final JavaMailSender mailSender;
-  // private final RedisManager redisManager;
+  private final JavaMailSender mailSender;
 
   @Value("${spring.mail.username}")
   private String FROM_ADDRESS;
@@ -33,9 +31,7 @@ public class AcoMailSender {
     message.setSubject(title);
     message.setText(context);
     // 메일 전송
-    // mailSender.send(message);
-    // redis에 email 값 + 유효기간 저장
-    // redisManager.setDataExpire(key, value, expiration : 60*5L);
+    mailSender.send(message);
     log.info("메일이 발송되었습니다" + message);
   }
 }

--- a/src/main/java/dev/aco/back/service/MailService/MailService.java
+++ b/src/main/java/dev/aco/back/service/MailService/MailService.java
@@ -1,9 +1,9 @@
 package dev.aco.back.service.MailService;
 
 public interface MailService {
-  boolean mailCheckingRequest(String email);
+  boolean sendEmail(String email);
 
-  String mailCheckingNumCheckRequest(String email, Integer authNum);
+  // String mailCheckingNumCheckRequest(String email, Integer authNum);
 
   boolean verifyEmail(String key);
 }

--- a/src/main/java/dev/aco/back/service/MailService/MailService.java
+++ b/src/main/java/dev/aco/back/service/MailService/MailService.java
@@ -1,6 +1,7 @@
 package dev.aco.back.service.MailService;
 
 public interface MailService {
+  // 이름이 AcoMailSender 의 send 매서드와 햇갈리는데 뭐가 좋을까요? 상관없을까요?
   boolean sendEmail(String email);
 
   // String mailCheckingNumCheckRequest(String email, Integer authNum);

--- a/src/main/java/dev/aco/back/service/MailService/MailServiceImpl.java
+++ b/src/main/java/dev/aco/back/service/MailService/MailServiceImpl.java
@@ -1,75 +1,75 @@
-// package dev.aco.back.service.MailService;
+package dev.aco.back.service.MailService;
 
-// import java.time.LocalDateTime;
-// import java.time.temporal.ChronoUnit;
-// import java.util.Optional;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
-// import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Service;
 
-// import dev.aco.back.Entity.User.emailAuth;
-// import dev.aco.back.Repository.MailRepository;
-// import dev.aco.back.Utils.Redis.RedisManager;
-// import jakarta.transaction.Transactional;
-// import lombok.RequiredArgsConstructor;
+import dev.aco.back.Entity.User.emailAuth;
+import dev.aco.back.Repository.MailRepository;
+import dev.aco.back.Utils.Redis.RedisManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 
-// @Service
-// @RequiredArgsConstructor
-// public class MailServiceImpl implements MailService {
-// private final AcoMailSender mailSender;
-// private final MailRepository mrepo;
-// private final RedisManager redisManager;
+@Service
+@RequiredArgsConstructor
+public class MailServiceImpl implements MailService {
+  private final AcoMailSender mailSender;
+  private final MailRepository mrepo;
+  private final RedisManager redisManager;
 
-// @Override
-// public boolean mailCheckingRequest(String email) {
+  @Override
+  public boolean mailCheckingRequest(String email) {
 
-// // 인증번호 생성
-// Integer authnum = (int) (Math.floor(Math.random() * 10000) - 1);
-// // 인증 객체
-// Optional<emailAuth> isCheck = mrepo.getByEmail(email);
-// // 존재한다면
-// if (isCheck.isPresent()) {
-// mrepo.delete(isCheck.get());
-// }
-// mrepo.save(emailAuth.builder().email(email).authNum(authnum).isAuthrized(false).build());
-// mailSender.send(email, "[ACO] 이메일 인증을 위한 인증번호를 안내드립니다.", "인증번호 : " +
-// authnum);
-// //여기서 redisManager.setDataExpire()매서드 실행하면서 유효기간 저장함.
-// return true;
-// }
+    // 인증번호 생성
+    Integer authnum = (int) (Math.floor(Math.random() * 10000) - 1);
+    // 인증 객체
+    Optional<emailAuth> isCheck = mrepo.getByEmail(email);
+    // 존재한다면
+    if (isCheck.isPresent()) {
+      mrepo.delete(isCheck.get());
+    }
+    mrepo.save(emailAuth.builder().email(email).authNum(authnum).isAuthrized(false).build());
+    mailSender.send(email, "[ACO] 이메일 인증을 위한 인증번호를 안내드립니다.", "인증번호 : " +
+        authnum);
+    // 여기서 redisManager.setDataExpire()매서드 실행하면서 유효기간 저장함.
+    return true;
+  }
 
-// @Override
-// @Transactional
-// public String mailCheckingNumCheckRequest(String email, Integer authNum) {
-// Optional<emailAuth> isCheck = mrepo.getByEmail(email);
-// if (isCheck.isPresent()) {
-// LocalDateTime now = LocalDateTime.now();
-// LocalDateTime pastTime = isCheck.get().getCreatedDateTime().plusMinutes(3);
-// if (ChronoUnit.SECONDS.between(now, pastTime) <= 0) {
-// return "인증시간이 만료되었습니다";
-// }
-// if (isCheck.get().getAuthNum().intValue() == authNum.intValue() &&
-// isCheck.get().getIsAuthrized() == false) {
-// mrepo.updateAuthTime(isCheck.get().getEauthId(),
-// isCheck.get().getCreatedDateTime().plusMinutes(60));
-// return "인증이 완료되었습니다 1시간 이내에 가입을 완료해주세요";
-// } else if (isCheck.get().getAuthNum().intValue() == authNum.intValue()
-// && isCheck.get().getIsAuthrized() == true) {
-// return "이미 인증된 이메일입니다 가입을 완료해주세요";
-// } else {
-// return "인증 번호가 잘못되었습니다";
-// }
-// } else {
-// return "잘못된 접근입니다";
-// }
-// }
+  @Override
+  @Transactional
+  public String mailCheckingNumCheckRequest(String email, Integer authNum) {
+    Optional<emailAuth> isCheck = mrepo.getByEmail(email);
+    if (isCheck.isPresent()) {
+      LocalDateTime now = LocalDateTime.now();
+      LocalDateTime pastTime = isCheck.get().getCreatedDateTime().plusMinutes(3);
+      if (ChronoUnit.SECONDS.between(now, pastTime) <= 0) {
+        return "인증시간이 만료되었습니다";
+      }
+      if (isCheck.get().getAuthNum().intValue() == authNum.intValue() &&
+          isCheck.get().getIsAuthrized() == false) {
+        mrepo.updateAuthTime(isCheck.get().getEauthId(),
+            isCheck.get().getCreatedDateTime().plusMinutes(60));
+        return "인증이 완료되었습니다 1시간 이내에 가입을 완료해주세요";
+      } else if (isCheck.get().getAuthNum().intValue() == authNum.intValue()
+          && isCheck.get().getIsAuthrized() == true) {
+        return "이미 인증된 이메일입니다 가입을 완료해주세요";
+      } else {
+        return "인증 번호가 잘못되었습니다";
+      }
+    } else {
+      return "잘못된 접근입니다";
+    }
+  }
 
-// //레퍼런스 참고하면서 임시로 만든 매서드 입니다. 이런식으로 되야하는지 잘 모르겠습니다.
-// public boolean verifyEmail(String key){
-// String email = redisManager.getEmailData(key);
-// if(email == null){
-// redisManager.deleteEmailData(key);
-// return false;
-// }
-// return true;
-// }
-// }
+  // 레퍼런스 참고하면서 임시로 만든 매서드 입니다. 이런식으로 되야하는지 잘 모르겠습니다.
+  public boolean verifyEmail(String key) {
+    String email = redisManager.getEmailData(key);
+    if (email == null) {
+      redisManager.deleteEmailData(key);
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/dev/aco/back/service/MailService/MailServiceImpl.java
+++ b/src/main/java/dev/aco/back/service/MailService/MailServiceImpl.java
@@ -1,7 +1,7 @@
 package dev.aco.back.service.MailService;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+// import java.time.LocalDateTime;
+// import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 import dev.aco.back.Entity.User.emailAuth;
 import dev.aco.back.Repository.MailRepository;
 import dev.aco.back.Utils.Redis.RedisManager;
-import jakarta.transaction.Transactional;
+// import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -20,8 +20,7 @@ public class MailServiceImpl implements MailService {
   private final RedisManager redisManager;
 
   @Override
-  public boolean mailCheckingRequest(String email) {
-
+  public boolean sendEmail(String email) {
     // 인증번호 생성
     Integer authnum = (int) (Math.floor(Math.random() * 10000) - 1);
     // 인증 객체
@@ -31,45 +30,51 @@ public class MailServiceImpl implements MailService {
       mrepo.delete(isCheck.get());
     }
     mrepo.save(emailAuth.builder().email(email).authNum(authnum).isAuthrized(false).build());
-    mailSender.send(email, "[ACO] 이메일 인증을 위한 인증번호를 안내드립니다.", "인증번호 : " +
-        authnum);
-    // 여기서 redisManager.setDataExpire()매서드 실행하면서 유효기간 저장함.
+    // redis에 email, 값, 유효기간 저장 (key : email , value : authnum, expiration : 60*5L )
+    redisManager.setDataExpire(email, authnum.toString(), 60 * 5L);
+    // 메일 발송
+    mailSender.send(email, "[ACO] 이메일 인증을 위한 인증번호를 안내드립니다.", "인증번호 : " + authnum);
+
     return true;
   }
 
-  @Override
-  @Transactional
-  public String mailCheckingNumCheckRequest(String email, Integer authNum) {
-    Optional<emailAuth> isCheck = mrepo.getByEmail(email);
-    if (isCheck.isPresent()) {
-      LocalDateTime now = LocalDateTime.now();
-      LocalDateTime pastTime = isCheck.get().getCreatedDateTime().plusMinutes(3);
-      if (ChronoUnit.SECONDS.between(now, pastTime) <= 0) {
-        return "인증시간이 만료되었습니다";
-      }
-      if (isCheck.get().getAuthNum().intValue() == authNum.intValue() &&
-          isCheck.get().getIsAuthrized() == false) {
-        mrepo.updateAuthTime(isCheck.get().getEauthId(),
-            isCheck.get().getCreatedDateTime().plusMinutes(60));
-        return "인증이 완료되었습니다 1시간 이내에 가입을 완료해주세요";
-      } else if (isCheck.get().getAuthNum().intValue() == authNum.intValue()
-          && isCheck.get().getIsAuthrized() == true) {
-        return "이미 인증된 이메일입니다 가입을 완료해주세요";
-      } else {
-        return "인증 번호가 잘못되었습니다";
-      }
-    } else {
-      return "잘못된 접근입니다";
-    }
-  }
+  // @Override
+  // @Transactional
+  // public String mailCheckingNumCheckRequest(String email, Integer authNum) {
+  // Optional<emailAuth> isCheck = mrepo.getByEmail(email);
+  // if (isCheck.isPresent()) {
+  // LocalDateTime now = LocalDateTime.now();
+  // LocalDateTime pastTime = isCheck.get().getCreatedDateTime().plusMinutes(3);
+  // if (ChronoUnit.SECONDS.between(now, pastTime) <= 0) {
+  // return "인증시간이 만료되었습니다";
+  // }
+  // if (isCheck.get().getAuthNum().intValue() == authNum.intValue() &&
+  // isCheck.get().getIsAuthrized() == false) {
+  // mrepo.updateAuthTime(isCheck.get().getEauthId(),
+  // isCheck.get().getCreatedDateTime().plusMinutes(60));
+  // return "인증이 완료되었습니다 1시간 이내에 가입을 완료해주세요";
+  // } else if (isCheck.get().getAuthNum().intValue() == authNum.intValue()
+  // && isCheck.get().getIsAuthrized() == true) {
+  // return "이미 인증된 이메일입니다 가입을 완료해주세요";
+  // } else {
+  // return "인증 번호가 잘못되었습니다";
+  // }
+  // } else {
+  // return "잘못된 접근입니다";
+  // }
+  // }
 
-  // 레퍼런스 참고하면서 임시로 만든 매서드 입니다. 이런식으로 되야하는지 잘 모르겠습니다.
+  // Transactional 어노테이션이 필요한거같은데 맞을까요?
+  // 검색해봤는데 이해가 아직 잘 가질 않습니다 T-T
   public boolean verifyEmail(String key) {
     String email = redisManager.getEmailData(key);
-    if (email == null) {
+    if (email != null) {
+      // redis에 EmailData가 있으면
       redisManager.deleteEmailData(key);
+      return true;
+    } else {
+      // redis에 EmailData가 없으면 = 인증실패
       return false;
     }
-    return true;
   }
 }


### PR DESCRIPTION
**고친부분**

1. AcoMailSender.java 클래스에 있었던 redisManager.setDataExpire를 MailService 클래스로 옮겼습니다. 

2. emailAuthDTO 클래스를 생성했습니다.

3. 기존에 있던 MailService 클래스에 작성되었던 mailCheckingNumRequest 매서드는 필요 없어진 것 같아 주석 처리했습니다. 

4. EmailController 클래스를 생성했습니다 
 
-------------------------------------------------------------------------------------------
**제가 이해하고 작성한.. 기본적인 흐름** 

1. 사용자가 회원가입을 하려고 request를 보내면 EmailController를 통해mailService.sendEmail을 호출합니다.  
2. 여기선 인증번호 생성과 해당 이메일이 mailRepository에 존재하는지 확인합니다. 만약 존재한다면 이메일, 인증번호와 인증여부(default = false)를 저장합니다.
3. 해당정보는 Redis에게도 보내집니다.  RedisManger를 통해 유효기간 또한 셋팅합니다.
6. AcoMailSender.send() 매서드를 호출하며 메일을 보냅니다.

7. 메일인증 검사는  EmailController가 요청에 따라 verifyMail을 호출하며 이는 MailService에서 동작됩니다. 
8. 보내온 정보들이 Redis 에 들어있는지 확인하기 위해 redisManger.getEmailData를 호출합니다.
9. delete를 이용해 비워줍니다.
10.  if 조건문을 사용해 결과에 따라 true(인증성공), false(인증실패)를 반환합니다.
-------------------------------------------------------------------------------------------


작명하는것 부터 중구난방이라.. 어떻게 작성하는 것이 좋을지 모르겠습니다 그리고 뭔가 빠진부분이 있는것 같습니다.  피드백 주시면 정말 감사하겠습니다.