### PR TITLE
[Hyunseok] Implement article modify/delete function

### DIFF
--- a/src/main/java/dev/aco/back/Controller/ArticleController.java
+++ b/src/main/java/dev/aco/back/Controller/ArticleController.java
@@ -62,6 +62,11 @@ public class ArticleController {
         return new ResponseEntity<>(aser.write(dto), HttpStatus.OK);
     }
 
+    @PostMapping(value = "modify", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Long> modify(ArticleDTO dto) {
+        return new ResponseEntity<>(aser.articleModify(dto), HttpStatus.OK);
+    }
+
     @PostMapping(value = "reply/write")
     public ResponseEntity<Boolean> writeReply(@RequestBody ReplyDTO dto){
         return new ResponseEntity<>(rser.writeReply(dto), HttpStatus.OK);

--- a/src/main/java/dev/aco/back/Controller/ArticleController.java
+++ b/src/main/java/dev/aco/back/Controller/ArticleController.java
@@ -67,6 +67,11 @@ public class ArticleController {
         return new ResponseEntity<>(aser.articleModify(dto), HttpStatus.OK);
     }
 
+    @PostMapping(value = "delete")
+    public ResponseEntity<Long> delete(ArticleDTO dto) {
+        return new ResponseEntity<>(aser.articleModify(dto), HttpStatus.OK);
+    }
+
     @PostMapping(value = "reply/write")
     public ResponseEntity<Boolean> writeReply(@RequestBody ReplyDTO dto){
         return new ResponseEntity<>(rser.writeReply(dto), HttpStatus.OK);

--- a/src/main/java/dev/aco/back/Repository/ArticleRepository.java
+++ b/src/main/java/dev/aco/back/Repository/ArticleRepository.java
@@ -1,11 +1,14 @@
 package dev.aco.back.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import dev.aco.back.Entity.Article.Article;
 import dev.aco.back.Entity.Enum.Menu;
@@ -25,4 +28,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     @EntityGraph(attributePaths = {"member"})
     Page<Article> findAllByMenuEquals(Pageable pageable, Menu menu);
 
+    @Modifying
+    @Query("UPDATE Article att set att.articleContext=:context, att.menu=:menu where att.articleId=:articleId")
+    void updateArticle(byte[] context, Menu menu, Long articleId);
+
+    @EntityGraph(attributePaths = {"member", "hashLinker", "articleImages", "nouns", "hashLinker.hashtag"})
+    Optional<Article> findById(Long id);
 }

--- a/src/main/java/dev/aco/back/service/ArticleService/ArticleService.java
+++ b/src/main/java/dev/aco/back/service/ArticleService/ArticleService.java
@@ -14,6 +14,7 @@ public interface ArticleService {
     List<ArticleDTO> readList(Pageable request);
     List<ArticleDTO> readListByMemberId(Pageable request, Long memberId);
     List<ArticleDTO> readListByKeywords(Pageable request, String keywords);
+    Long articleModify (ArticleDTO dto);
 
     List<ArticleDTO> readListByMenu(Pageable request, Integer menuId);
     Long write(ArticleDTO dto);

--- a/src/main/java/dev/aco/back/service/ArticleService/ArticleService.java
+++ b/src/main/java/dev/aco/back/service/ArticleService/ArticleService.java
@@ -15,7 +15,7 @@ public interface ArticleService {
     List<ArticleDTO> readListByMemberId(Pageable request, Long memberId);
     List<ArticleDTO> readListByKeywords(Pageable request, String keywords);
     Long articleModify (ArticleDTO dto);
-
+    Boolean articleDelete (Long articleId);
     List<ArticleDTO> readListByMenu(Pageable request, Integer menuId);
     Long write(ArticleDTO dto);
 

--- a/src/main/java/dev/aco/back/service/ArticleService/ArticleServiceImpl.java
+++ b/src/main/java/dev/aco/back/service/ArticleService/ArticleServiceImpl.java
@@ -102,8 +102,9 @@ public class ArticleServiceImpl implements ArticleService {
 	@Transactional
 	public Long articleModify(ArticleDTO dto) {
 		Article article = arepo.findById(dto.getArticleId()).orElseThrow();
-
-		airepo.deleteAllById(article.getArticleImages().stream().map(v->v.getArticleImageId()).toList());
+		List<ArticleImage> delImg = article.getArticleImages().stream().filter(v->!dto.getArticleImagesNames().contains(v.getImg())).toList();
+		airepo.deleteAll(delImg);
+		
 		Optional.ofNullable(dto.getArticleImages()).ifPresentOrElse((images) -> {
 			images.forEach((image) -> {
 				String uploadedImgStr = imageManager.ImgUpload(image).toString();

--- a/src/main/java/dev/aco/back/service/ArticleService/ArticleServiceImpl.java
+++ b/src/main/java/dev/aco/back/service/ArticleService/ArticleServiceImpl.java
@@ -63,7 +63,6 @@ public class ArticleServiceImpl implements ArticleService {
 	@Override
 	public List<ArticleDTO> readListByMenu(Pageable request, Integer menuId) {
 		return arepo.findAllByMenuEquals(request, Menu.values()[menuId]).stream().map(v->toDTO(v)).toList();
-		//    0: Diary, 1: Tip, 2:Question
 	}
 
 	// =========================================================================================================================================================
@@ -137,6 +136,16 @@ public class ArticleServiceImpl implements ArticleService {
 		arepo.updateArticle(dto.getArticleContext().getBytes(), Menu.valueOf(dto.getMenu()), article.getArticleId());
 		return article.getArticleId();
 
+	}
+
+	@Override
+	public Boolean articleDelete(Long articleId) {
+		try {
+			arepo.deleteById(articleId);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 


### PR DESCRIPTION
글수정:
수정하는 기능은 글쓰기랑 똑같이 보내시면 됩니다 
addPosts주소를  write냐 modify냐로 나눠서 그냥 보내면 하나에 다 쓸 수있을겁니다

이미지는 이미 받아온 파일이름을 tag랑 똑같이 form에다 currentImage이름으로 담아서 보내주세용(안넣으면 지워집니다)
또한 새로 추가될 이미지는 기존에 addPosts처럼 똑같이 articleImage에 넣어주시면됩니다

추가로 수정이기때문에 data보내실때 articleId도 form에 추가해서 같이 보내주세용

이 로직 그대로면 이미지 수정안하고 그냥 보냈을때 basic.png이 
함 더 들어갈듯한데 요건 멤버 비교할때 같이 고쳐놓을게영

글삭제:
articleId만 보내주세용

아직 남은 작업:
글쓰기/삭제할때 header에서 토큰 가져와서 
글쓴이랑 비교해서 맞는지 확인하기 