### PR TITLE
[Hyunseok] Implement user resignment

### DIFF
--- a/src/main/java/dev/aco/back/Controller/ImageController.java
+++ b/src/main/java/dev/aco/back/Controller/ImageController.java
@@ -29,7 +29,7 @@ public class ImageController {
         return new ResponseEntity<>(file, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/user/{name}")
+    @GetMapping(value = "/user/{memberid}")
     public ResponseEntity<byte[]> imageReadByMemberId(@PathVariable("memberid") Long memberid) {
         return new ResponseEntity<>(mser.getImageByMemberId(memberid), HttpStatus.OK);
     }

--- a/src/main/java/dev/aco/back/Controller/ImageController.java
+++ b/src/main/java/dev/aco/back/Controller/ImageController.java
@@ -1,6 +1,5 @@
 package dev.aco.back.Controller;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,12 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import dev.aco.back.Utils.Image.ImageManager;
+import dev.aco.back.service.MemberService.MemberService;
 import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/image")
 public class ImageController {
     private final ImageManager imageManager;
+    private final MemberService mser;
     @PostMapping(value = "upload")
     public ResponseEntity<String> imageUpload(MultipartFile request) {
         return new ResponseEntity<>(imageManager.ImgUpload(request), HttpStatus.OK);
@@ -25,8 +26,12 @@ public class ImageController {
     @GetMapping(value = "/images/{name}")
     public ResponseEntity<byte[]> imageRead(@PathVariable("name") String name) {
         byte[] file = (byte[]) imageManager.ImgRead(name).get(0);
-        HttpHeaders header = new HttpHeaders();
-        header.add("Content-Type", imageManager.ImgRead(name).get(1).toString());
-        return new ResponseEntity<>(file, header, HttpStatus.OK);
+        return new ResponseEntity<>(file, HttpStatus.OK);
     }
+
+    @GetMapping(value = "/user/{name}")
+    public ResponseEntity<byte[]> imageReadByMemberId(@PathVariable("memberid") Long memberid) {
+        return new ResponseEntity<>(mser.getImageByMemberId(memberid), HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/dev/aco/back/Controller/MemberController.java
+++ b/src/main/java/dev/aco/back/Controller/MemberController.java
@@ -21,7 +21,10 @@ public class MemberController {
 
     private final MemberService mser;
 
-
+    @PostMapping("/resign")
+    public ResponseEntity<Boolean> memberResign(@RequestBody MemberDTO dto){
+        return new ResponseEntity<Boolean>(mser.memberResign(dto), HttpStatus.OK);
+    }
 
 
 

--- a/src/main/java/dev/aco/back/Security/Filter/CustomUserFilter.java
+++ b/src/main/java/dev/aco/back/Security/Filter/CustomUserFilter.java
@@ -58,7 +58,7 @@ public class CustomUserFilter extends OncePerRequestFilter {
             }
 
             if (!atkBool){
-                List<String> tokenList = jwtManager.AccessRefreshGenerator(rtknMember.getMemberId(), rtknMember.getEmail());
+                List<String> tokenList = jwtManager.AccessRefreshGenerator(rtknMember.getMemberId(), rtknMember.getEmail(), rtknMember.getUserimg());
                 redisManager.setRefreshToken(tokenList.get(1), rtknMember.getMemberId());
 
                 if(rtknMember.getNickname().length()==0 || rtknMember.getPassword().length()==0){

--- a/src/main/java/dev/aco/back/Security/Handler/CustomSuccessHandler.java
+++ b/src/main/java/dev/aco/back/Security/Handler/CustomSuccessHandler.java
@@ -33,7 +33,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             Authentication authentication) throws IOException, ServletException {
         Member member = mrepo.findByEmail(authentication.getName()).get();
         log.info(member.getNickname());
-        List<String> tokenList = jwtManager.AccessRefreshGenerator(member.getMemberId(), member.getEmail());
+        List<String> tokenList = jwtManager.AccessRefreshGenerator(member.getMemberId(), member.getEmail(), member.getUserimg());
         redisManager.setRefreshToken(tokenList.get(1), member.getMemberId());
 
         // 요건 혹시 몰라서 살려둘게용

--- a/src/main/java/dev/aco/back/Utils/JWT/JWTManager.java
+++ b/src/main/java/dev/aco/back/Utils/JWT/JWTManager.java
@@ -27,16 +27,16 @@ public class JWTManager {
     private String secretKey;
     private final long DAY = 259200000 / 3;
 
-    public List<String> AccessRefreshGenerator(Long memberId, String email){
+    public List<String> AccessRefreshGenerator(Long memberId, String email, String userimg){
         List<String> tokenAry = new ArrayList<>();
-        tokenAry.add(tokenGenerate(memberId, email, 1L));
-        tokenAry.add(tokenGenerate(memberId, email, 7L));
+        tokenAry.add(tokenGenerate(memberId, email, 1L, userimg));
+        tokenAry.add(tokenGenerate(memberId, email, 7L, userimg));
 
         return tokenAry;
 
     }
 
-    public String tokenGenerate(Long memberId, String email, Long expireRate) {
+    public String tokenGenerate(Long memberId, String email, Long expireRate, String userimg) {
         SecretKey key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
         Date today = new Date();
         String jwt = Jwts.builder()
@@ -45,6 +45,7 @@ public class JWTManager {
                 .setExpiration(new Date(today.getTime() + ((DAY / 24 / 6) * expireRate)))
                 .claim("email", email)
                 .claim("userNumber", memberId)
+                .claim("userimg", userimg)
                 .setSubject("bblog token")
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();

--- a/src/main/java/dev/aco/back/service/MemberService/MemberService.java
+++ b/src/main/java/dev/aco/back/service/MemberService/MemberService.java
@@ -10,6 +10,7 @@ import dev.aco.back.Entity.User.Member;
 public interface MemberService {
   Boolean signUp(MemberDTO dto);
   Boolean emailChecking(MemberDTO dto);
+  byte[] getImageByMemberId(Long memberId);
 
   // Long findPassword(findPassword vo);
   // String changePassword(changePassword vo);

--- a/src/main/java/dev/aco/back/service/MemberService/MemberService.java
+++ b/src/main/java/dev/aco/back/service/MemberService/MemberService.java
@@ -11,6 +11,7 @@ public interface MemberService {
   Boolean signUp(MemberDTO dto);
   Boolean emailChecking(MemberDTO dto);
   byte[] getImageByMemberId(Long memberId);
+  Boolean memberResign(MemberDTO dto);
 
   // Long findPassword(findPassword vo);
   // String changePassword(changePassword vo);

--- a/src/main/java/dev/aco/back/service/MemberService/MemberServiceImpl.java
+++ b/src/main/java/dev/aco/back/service/MemberService/MemberServiceImpl.java
@@ -31,6 +31,17 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
+  @Transactional
+  public Boolean memberResign(MemberDTO dto) {
+      Member member = repo.findById(dto.getMemberId()).orElse(Member.builder().memberId(-1L).password("-1").build());
+      if(encoder.matches(dto.getPassword(), member.getPassword())){
+        repo.delete(member);
+        return true;
+      }
+      return false;
+  }
+
+  @Override
   public byte[] getImageByMemberId(Long memberId) {
     String imgName = repo.findById(memberId).orElse(Member.builder().userimg("basic.png").build()).getUserimg();
     return (byte[])imageManager.ImgRead(imgName).get(0);

--- a/src/main/java/dev/aco/back/service/MemberService/MemberServiceImpl.java
+++ b/src/main/java/dev/aco/back/service/MemberService/MemberServiceImpl.java
@@ -9,9 +9,11 @@ import org.springframework.stereotype.Service;
 
 import dev.aco.back.DTO.User.MemberDTO;
 import dev.aco.back.Entity.Enum.Roles;
+import dev.aco.back.Entity.User.Member;
 import dev.aco.back.Entity.User.emailAuth;
 import dev.aco.back.Repository.MailRepository;
 import dev.aco.back.Repository.MemberRepository;
+import dev.aco.back.Utils.Image.ImageManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
@@ -21,10 +23,17 @@ public class MemberServiceImpl implements MemberService {
   private final MemberRepository repo;
   private final PasswordEncoder encoder;
   private final MailRepository mrepo;
+  private final ImageManager imageManager;
 
   @Override
   public Boolean emailChecking(MemberDTO dto) {
     return repo.existsByEmail(dto.getEmail());
+  }
+
+  @Override
+  public byte[] getImageByMemberId(Long memberId) {
+    String imgName = repo.findById(memberId).orElse(Member.builder().userimg("basic.png").build()).getUserimg();
+    return (byte[])imageManager.ImgRead(imgName).get(0);
   }
 
   @Transactional


### PR DESCRIPTION
{
  "memberId": 유저번호,
  "password": "유저비밀번호"
}

유저번호랑 비밀번호만 날려주시면 db랑 비교해서 지우게끔 만들어뒀어용  
주소는 ./api/member/resign으로 post 날려주시면 bool값으로 성공/실패 리턴합니다