### PR TITLE
[Hyunseok] Fix hashtag issue when write article

### DIFF
--- a/src/main/java/dev/aco/back/service/ArticleService/ArticleServiceImpl.java
+++ b/src/main/java/dev/aco/back/service/ArticleService/ArticleServiceImpl.java
@@ -70,12 +70,14 @@ public class ArticleServiceImpl implements ArticleService {
 	@Override
 	@Transactional
 	public Long write(ArticleDTO dto) {
+		System.out.println(">><>>>>>>>>>>>>>>>>>>>>>....");
+		System.out.println(dto.getTags());
 		Optional<List<MultipartFile>> imgs = Optional.ofNullable(dto.getArticleImages());
 		Article article = dtoToEntity(dto);
 		List<String> phrases = nounExtractor(dto.getArticleContext());
 		List<Hashtag> tags = dto.getTags()
 								.stream()
-								.map(v-> hrepo.findByTag(v).orElse(hrepo.save(Hashtag.builder().tag(v).build())))
+								.map(v-> hrepo.findByTag(v).orElseGet(()-> hrepo.save(Hashtag.builder().tag(v).build())))
 									.toList();
 									
 


### PR DESCRIPTION
orElse > orElseGet으로 변경

.map(v-> hrepo.findByTag(v).orElse(hrepo.save(Hashtag.builder().tag(v).build())))
이 구문에서, orElse일 경우, 
findByTag값이 null이던 null이 아니던 
일단 hrepo.save가 **실행되고 null값이면 실행된 값을 가져옴**

orElseGet으로 "()->hrepo.save" **자체를** 넘겨 
null이 아니어도 실행하는게 아닌 
null일 경우에 람다식을 실행하도록 변경 



